### PR TITLE
[DE-2293] Adds configs for 'high usage' scripts and utility to generate them.

### DIFF
--- a/categories.sh
+++ b/categories.sh
@@ -2,6 +2,8 @@
 set -e
 
 # export these variables
+declare -x GoNotoHighUsageScriptsRegular
+declare -x GoNotoHighUsageScriptsBold
 declare -x GoNotoAncient
 declare -x GoNotoCurrentRegular
 declare -x GoNotoCurrentSerif
@@ -289,6 +291,28 @@ GoNotoCurrentBold=(
     "NotoSansSymbols2-Regular.ttf" # No bold
     "NotoSansMathSubset-Regular.ttf" # No bold
     "NotoMusic-Regular.ttf" # No bold
+)
+
+GoNotoHighUsageScriptsRegular=(
+    "NotoSans-Regular.ttf" # Base font with Latin, Greek, Cyrillic, etc.
+    "NotoSansCJKjpSubset-Regular.ttf" # Japanese
+    "NotoSansArabic-Regular.ttf" # Arabic, Urdu, Pashto, etc.
+    "NotoSansCJKscSubset-Regular.ttf" # Simplified Chinese
+    "NotoSansCJKkrSubset-Regular.ttf" # Korean
+    "NotoSansDevanagari-Regular.ttf" # Hindi, Marathi, Nepali, etc.
+    "NotoSansHebrew-Regular.ttf" # Hebrew
+    "NotoSansThai-Regular.ttf" # Thai
+)
+
+GoNotoHighUsageScriptsBold=(
+    "NotoSans-Bold.ttf" # Base font with Latin, Greek, Cyrillic, etc.
+    "NotoSansCJKjpSubset-Bold.ttf" # Japanese
+    "NotoSansArabic-SemiBold.ttf" # Arabic, Urdu, Pashto, etc.
+    "NotoSansCJKscSubset-Bold.ttf" # Simplified Chinese
+    "NotoSansCJKkrSubset-Bold.ttf" # Korean
+    "NotoSansDevanagari-Bold.ttf" # Hindi, Marathi, Nepali, etc.
+    "NotoSansHebrew-Bold.ttf" # Hebrew
+    "NotoSansThai-Bold.ttf" # Thai
 )
 
 GoNotoAfricaMiddleEast=(

--- a/usage_fonts.sh
+++ b/usage_fonts.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+[[ -z "$VIRTUAL_ENV" ]] && echo "Refusing to run outside of venv. See README.md." && exit 100
+
+python3 -m pip install 'fonttools >= 4.41.1'
+
+# import functions and globals
+source url.sh
+source helper.sh
+source categories.sh
+
+# --- execution starts here ---
+mkdir -p cache/
+
+# GoNotoCurrentRegular.ttf
+create_cjk_subset
+# create_duployan_subset
+create_japanese_kana_subset
+create_korean_hangul_subset
+# create_math_subset
+create_tibetan_subset
+# create_go_noto_current_with_full_korean
+
+# drop_vertical_tables NotoSansMongolian-Regular.ttf
+# drop_vertical_tables NotoSansNushu-Regular.ttf
+# drop_vertical_tables NotoTraditionalNushu-Bold.ttf
+
+
+echo "Generating GoNotoHighUsageScriptsRegular.ttf. Current time: $(date)."
+go_build GoNotoHighUsageScriptsRegular.ttf "${GoNotoHighUsageScriptsRegular[@]}"
+
+echo "Generating GoNotoHighUsageScriptsBold.ttf. Current time: $(date)."
+go_build GoNotoHighUsageScriptsBold.ttf "${GoNotoHighUsageScriptsBold[@]}"


### PR DESCRIPTION
Adds a 'usage' set of noto scripts. This aims to capture the 'most used' set of scripts to find a compromise between file-size and support. "Most used" is referencing [this data](https://en.wikipedia.org/wiki/Languages_used_on_the_Internet) i.e. the most-used scripts that appear on the internet, rather than trying to get a measure based on the number of people who can read a particular script.

